### PR TITLE
fix: changed remote network to id

### DIFF
--- a/main_network_1.tf
+++ b/main_network_1.tf
@@ -172,5 +172,5 @@ resource "azurerm_virtual_network_peering" "peering-1-to-2" {
   name                        = "peering_vnet-1_vnet-2"
   resource_group_name         = azurerm_resource_group.rg-vnet-1.name
   virtual_network_name        = azurerm_virtual_network.vnet-1.name
-  remote_virtual_network_id   = azurerm_virtual_network.vnet-2.name
+  remote_virtual_network_id   = azurerm_virtual_network.vnet-2.id
 }

--- a/main_network_2.tf
+++ b/main_network_2.tf
@@ -101,7 +101,7 @@ resource "azurerm_virtual_network_peering" "peering-2-to-1" {
   name                        = "peering_vnet-2_vnet-1"
   resource_group_name         = azurerm_resource_group.rg-vnet-2.name
   virtual_network_name        = azurerm_virtual_network.vnet-2.name
-  remote_virtual_network_id   = azurerm_virtual_network.vnet-1.name
+  remote_virtual_network_id   = azurerm_virtual_network.vnet-1.id
   allow_forwarded_traffic = true
   allow_virtual_network_access = true
 } 


### PR DESCRIPTION
resolves #3

Fixes a failure while peering two virtual networks together.
Changed remote network id property from name to id.